### PR TITLE
fix: return saga for chaining in catchApiException

### DIFF
--- a/redux/api/catchApiExceptions.js
+++ b/redux/api/catchApiExceptions.js
@@ -13,12 +13,14 @@ export default (
 ) =>
   function* (...args: any): SagaType {
     try {
-      const { hasTimeOuted } = yield race({
+      const { hasTimeOuted, executeApiSaga } = yield race({
         hasTimeOuted: call(delay, timeout),
         executeApiSaga: saga.apply(this, args),
       });
       if (hasTimeOuted) {
         handleApiException(new Error(TIMEOUT_ERROR));
+      } else {
+        return executeApiSaga;
       }
     } catch (error) {
       handleApiException(error);


### PR DESCRIPTION
Hi, 
If you want to use catchApiException in call

Sample : 
const data = yield call(catchApiExceptions(myApiSaga), param);
console.log(data)

Regards !
